### PR TITLE
app: Wrap build sections with details tag

### DIFF
--- a/app/fetcher/src/CommentRender.hs
+++ b/app/fetcher/src/CommentRender.hs
@@ -167,7 +167,7 @@ genBuildFailuresTable
           , M.parens $ T.pack $ MyUtils.renderFrac idx $ length non_upstream_breakages
           ]
       , T.unwords summary_info_pieces
-      ] <> code_block_lines
+      ] <> M.detailsExpander (M.tagElement "code" $ MatchOccurrences._line_text match_obj) code_block_lines
       where
         job_name = Builds.job_name build_obj
 


### PR DESCRIPTION
Allows for build sections to wrapped in a `<details>` tag to reduce the
spam from the comment itself.

<details>
<summary> Do note: </summary>

This is my first time working in Haskell so I'm not entirely sure if I got the syntax right.

</details>

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>